### PR TITLE
fix matching on 1.12 to make package test pass again

### DIFF
--- a/src/ParserGen.jl
+++ b/src/ParserGen.jl
@@ -85,7 +85,7 @@ function collect_context(node)
             IsMacro{:token} =>
                 begin
                     collector = @λ begin
-                        :($name := $node) -> push!(tokens, (name, node))
+                        :($name := $node) => push!(tokens, (name, node))
                         a -> throw(a)
                     end
                 end


### PR DESCRIPTION
Something in https://github.com/JuliaLang/JuliaSyntax.jl/pull/522 caused the package to no longer match things properly. I am not sure if this is a bug in the current parser or this was intended but this is a workaround at least..

The difference from 1.11 is that on 1.12 we have an extra tuple wrapping the LHS of the matching pattern changed in this PR:

```julia
julia> ex = quote
       :(ab) -> a
       end
quote
    #= REPL[29]:2 =#
    $(Expr(:quote, :((ab,))))->begin
            #= REPL[29]:2 =#
            a
        end
end

julia> dump(ex)
Expr
  head: Symbol block
  args: Array{Any}((2,))
    1: LineNumberNode
      line: Int64 2
      file: Symbol REPL[29]
    2: Expr
      head: Symbol ->
      args: Array{Any}((2,))
        1: Expr
          head: Symbol quote
          args: Array{Any}((1,))
            1: Expr
              head: Symbol tuple   # <---------------------------------
              args: Array{Any}((1,))
                1: Symbol ab
        2: Expr
          head: Symbol block
          args: Array{Any}((2,))
            1: LineNumberNode
              line: Int64 2
              file: Symbol REPL[29]
            2: Symbol a
```

