### PR TITLE
Make Julia1.12 compatible

### DIFF
--- a/src/Lexer.jl
+++ b/src/Lexer.jl
@@ -29,9 +29,9 @@ function _genlex(argsym, retsym, lexer_table, reserved_words)
 end
 
 rmlines = @λ begin
-    e :: Expr           -> Expr(e.head, filter(x -> x !== nothing, map(rmlines, e.args))...)
-      :: LineNumberNode -> nothing
-    a                   -> a
+    e :: Expr           => Expr(e.head, filter(x -> x !== nothing, map(rmlines, e.args))...)
+      :: LineNumberNode => nothing
+    a                   => a
 end
 
 struct LexerSpec{K}

--- a/src/ParserGen.jl
+++ b/src/ParserGen.jl
@@ -85,8 +85,8 @@ function collect_context(node)
             IsMacro{:token} =>
                 begin
                     collector = @λ begin
-                        :($name := $node) -> push!(tokens, (name, node))
-                        a -> throw(a)
+                        :($name := $node) => push!(tokens, (name, node))
+                        a => throw(a)
                     end
                 end
             IsMacro{:grammar} =>
@@ -408,9 +408,9 @@ function make(node, top, mod::Module)
 end
 
 rmlines = @λ begin
-           e :: Expr           -> Expr(e.head, filter(x -> x !== nothing, map(rmlines, e.args))...)
-             :: LineNumberNode -> nothing
-           a                   -> a
+           e :: Expr           => Expr(e.head, filter(x -> x !== nothing, map(rmlines, e.args))...)
+             :: LineNumberNode => nothing
+           a                   => a
 end
 
 


### PR DESCRIPTION
Tighter restrictions on -> vs => in 1.12 mean some of these functions no longer worked.

Tested in both 1.11 and 1.12